### PR TITLE
Attempt to implement #5

### DIFF
--- a/nofussbm/__init__.py
+++ b/nofussbm/__init__.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License along with
 # "No Fuss Bookmarks". If not, see <http://www.gnu.org/licenses/>.
 
-from logging import StreamHandler, Formatter, getLogger, DEBUG
+from logging import StreamHandler, Formatter, DEBUG
 from os import environ
 
-from flask import Flask, make_response, request, g, redirect, url_for, abort, render_template
+from flask import Flask, make_response, request, redirect, url_for, abort, render_template
 from flask.ext.pymongo import PyMongo
 
 from pymongo.errors import OperationFailure
@@ -41,6 +41,9 @@ mongo = PyMongo( app )
 from .api import api
 from .helpers import query_from_dict
 from .tags import tags
+from .json import NofussbmJSONEncoder, NofussbmJSONDecoder
+app.json_encoder = NofussbmJSONEncoder
+app.json_decoder = NofussbmJSONDecoder
 
 # Register APIs blueprint and setup {before,teardown}_request
 
@@ -58,7 +61,7 @@ app.register_blueprint( api, url_prefix = '/api/v1' )
 
 stderr_handler = StreamHandler()
 stderr_handler.setLevel( DEBUG )
-stderr_handler.setFormatter( Formatter( '%(asctime)s [%(process)s] [%(levelname)s] [Flask: %(name)s] %(message)s','%Y-%m-%d %H:%M:%S' ) )
+stderr_handler.setFormatter( Formatter( '%(asctime)s [%(process)s] [%(levelname)s] [Flask: %(name)s] %(message)s', '%Y-%m-%d %H:%M:%S' ) )
 app.logger.addHandler( stderr_handler )
 app.logger.setLevel( DEBUG )
 
@@ -136,7 +139,6 @@ def list( ident ):
 		if list_appearance == 'html':
 			for bm in list_query( email, bookmarks_per_page ):
 				date = bm[ 'date-modified' ]
-				print bm
 				result.append( ( date.strftime( '%Y-%m-%d' ), bm[ 'url' ], bm[ 'title' ], bm[ 'tags' ], bm[ '_id' ] ) )
 			if content_only:
 				return render_template( 'list-content.html', bookmarks = result )

--- a/nofussbm/api.py
+++ b/nofussbm/api.py
@@ -15,12 +15,13 @@
 # You should have received a copy of the GNU General Public License along with
 # "No Fuss Bookmarks". If not, see <http://www.gnu.org/licenses/>.
 
+import hmac
+import re
+
 from base64 import b64encode, b64decode
 from datetime import datetime
 from functools import wraps
 from hashlib import sha1
-import hmac
-import re
 from urlparse import parse_qs
 
 from flask import Blueprint, make_response, request, g, json, abort
@@ -34,11 +35,6 @@ api = Blueprint( 'api', __name__ )
 
 RANGE_RE = re.compile( r'bookmarks=(\d+)(-(\d+))?' )
 
-
-# Hacks (somehow horrible) to personalize decoding in Flask request.json
-
-from .helpers import setup_json
-setup_json( json )
 
 def myjsonify( data = None, code = 200, headers = None ):
 	data = [] if not data else data

--- a/nofussbm/json.py
+++ b/nofussbm/json.py
@@ -23,40 +23,40 @@ from .helpers import to_id
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 
 
-class NofussbmJSONEncoder(JSONEncoder):
+class NofussbmJSONEncoder( JSONEncoder ):
 
-    def default(self, obj):
-        if isinstance(obj, datetime):
-            return datetime.strftime(obj, DATETIME_FORMAT)
-        if isinstance(obj, ObjectId):
-            return str(obj)
-        return JSONEncoder.default(self, obj)
+    def default( self, obj ):
+        if isinstance( obj, datetime ):
+            return datetime.strftime( obj, DATETIME_FORMAT )
+        if isinstance( obj, ObjectId ):
+            return str( obj )
+        return JSONEncoder.default( self, obj )
 
 
-class NofussbmJSONDecoder(JSONDecoder):
+class NofussbmJSONDecoder( JSONDecoder ):
 
-    def __init__(self, *args, **kwargs):
-        self.ALLOWED_KEYS = set(['title', 'url', 'id', 'tags', 'date-added', 'date-modified'])
-        self.orig_object_hook = kwargs.pop("object_hook", None)
-        super(NofussbmJSONDecoder, self).__init__(*args, object_hook=self.custom_object_hook, **kwargs)
+    def __init__( self, *args, **kwargs ):
+        self.ALLOWED_KEYS = set( [ 'title', 'url', 'id', 'tags', 'date-added', 'date-modified' ] )
+        self.orig_object_hook = kwargs.pop( "object_hook", None )
+        super( NofussbmJSONDecoder, self ).__init__( *args, object_hook=self.custom_object_hook, **kwargs )
 
-    def custom_object_hook(self, dct):
+    def custom_object_hook( self, dct ):
         res = dict()
         for key, value in dct.items():
             if key not in self.ALLOWED_KEYS:
                 continue
             if key == 'id':
-                res['id'] = to_id(value)
+                res[ 'id' ] = to_id( value )
             elif key == 'tags':
                 try:
-                    res['tags'] = [_.strip() for _ in value.split(',')]
+                    res[ 'tags' ] =  [ _.strip() for _ in value.split( ',' ) ]
                 except AttributeError:
-                    res['tags'] = [_.strip() for _ in value]
-            elif key.startswith('date-'):
+                    res[ 'tags' ] =  [ _.strip() for _ in value]
+            elif key.startswith( 'date-' ):
                 try:
-                    res[key] = datetime.strptime(value, DATETIME_FORMAT)
+                    res[ key ] = datetime.strptime( value, DATETIME_FORMAT )
                 except:
                     pass
             else:
-                res[key] = value
+                res[ key ] = value
         return res

--- a/nofussbm/json.py
+++ b/nofussbm/json.py
@@ -1,0 +1,59 @@
+# Copyright 2011, Massimo Santini <santini@dsi.unimi.it>
+#
+# This file is part of "No Fuss Bookmarks".
+#
+# "No Fuss Bookmarks" is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# "No Fuss Bookmarks" is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# "No Fuss Bookmarks". If not, see <http://www.gnu.org/licenses/>.
+
+from flask.json import JSONEncoder, JSONDecoder
+from datetime import datetime
+from bson.objectid import ObjectId
+from .helpers import to_id
+
+DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
+
+
+class NofussbmJSONEncoder(JSONEncoder):
+
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return datetime.strftime(obj, DATETIME_FORMAT)
+        if isinstance(obj, ObjectId):
+            return str(obj)
+        return JSONEncoder.default(self, obj)
+
+
+class NofussbmJSONDecoder(JSONDecoder):
+
+    def __init__(self, *args, **kwargs):
+        self.ALLOWED_KEYS = set(['title', 'url', 'id', 'tags', 'date-added', 'date-modified'])
+        self.orig_object_hook = kwargs.pop("object_hook", None)
+        super(NofussbmJSONDecoder, self).__init__(*args, object_hook=self.custom_object_hook, **kwargs)
+
+    def custom_object_hook(self, dct):
+        res = dict()
+        for key, value in dct.items():
+            if key not in self.ALLOWED_KEYS:
+                continue
+            if key == 'id':
+                res['id'] = to_id(value)
+            elif key == 'tags':
+                res['tags'] = [_.strip() for _ in value.split(',')]
+            elif key.startswith('date-'):
+                try:
+                    res[key] = datetime.strptime(value, DATETIME_FORMAT)
+                except:
+                    pass
+            else:
+                res[key] = value
+        return res

--- a/nofussbm/json.py
+++ b/nofussbm/json.py
@@ -48,7 +48,10 @@ class NofussbmJSONDecoder(JSONDecoder):
             if key == 'id':
                 res['id'] = to_id(value)
             elif key == 'tags':
-                res['tags'] = [_.strip() for _ in value.split(',')]
+                try:
+                    res['tags'] = [_.strip() for _ in value.split(',')]
+                except AttributeError:
+                    res['tags'] = [_.strip() for _ in value]
             elif key.startswith('date-'):
                 try:
                     res[key] = datetime.strptime(value, DATETIME_FORMAT)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -41,11 +41,15 @@ class NofussbmJSONTestCase(unittest.TestCase):
                          '"title": "Google", '
                          '"url": "https://google.com"'
                          '}]')
+
         with self.app.app_context():
-            load = flask.json.loads(to_load)
+            load = flask.json.loads(to_load)  # expected_dump
             dump = flask.json.dumps(expected_load)
             self.assertEqual(load, expected_load)
             self.assertEqual(dump, expected_dump)
+
+            tags_as_list_load = flask.json.loads(expected_dump)
+            self.assertEqual(tags_as_list_load, expected_load)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,51 @@
+import unittest
+import nofussbm
+import flask
+import datetime
+
+from bson import ObjectId
+
+
+class NofussbmJSONTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.app = nofussbm.app
+        self.app.config['TESTING'] = True
+        self.client = nofussbm.app.test_client()
+
+    def tearDown(self):
+        pass
+
+    def testJson(self):
+        expected_load = [{
+            u'date-modified': datetime.datetime(2016, 7, 16, 0, 0, 43, 237000),
+            u'title': u'Google',
+            u'url': u'https://google.com',
+            u'tags': [u'google', u'search engine'],
+            u'id': ObjectId('5789792b19f4cb77cc3be929'),
+            u'date-added': datetime.datetime(2016, 7, 16, 0, 0, 43, 237000)
+        }]
+        to_load = ('[{'
+                   '"date-added": "2016-07-16 00:00:43.237000", '
+                   '"date-modified": "2016-07-16 00:00:43.237000", '
+                   '"id": "5789792b19f4cb77cc3be929", '
+                   '"tags": "google,search engine", '
+                   '"title": "Google", '
+                   '"url": "https://google.com"'
+                   '}]')
+        expected_dump = ('[{'
+                         '"date-added": "2016-07-16 00:00:43.237000", '
+                         '"date-modified": "2016-07-16 00:00:43.237000", '
+                         '"id": "5789792b19f4cb77cc3be929", '
+                         '"tags": ["google", "search engine"], '
+                         '"title": "Google", '
+                         '"url": "https://google.com"'
+                         '}]')
+        with self.app.app_context():
+            load = flask.json.loads(to_load)
+            dump = flask.json.dumps(expected_load)
+            self.assertEqual(load, expected_load)
+            self.assertEqual(dump, expected_dump)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -42,6 +42,9 @@ class NofussbmJSONTestCase(unittest.TestCase):
                          '"url": "https://google.com"'
                          '}]')
 
+        self.assertEqual(self.app.json_encoder, nofussbm.json.NofussbmJSONEncoder)
+        self.assertEqual(self.app.json_decoder, nofussbm.json.NofussbmJSONDecoder)
+
         with self.app.app_context():
             load = flask.json.loads(to_load)  # expected_dump
             dump = flask.json.dumps(expected_load)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -6,53 +6,53 @@ import datetime
 from bson import ObjectId
 
 
-class NofussbmJSONTestCase(unittest.TestCase):
+class NofussbmJSONTestCase( unittest.TestCase ):
 
-    def setUp(self):
+    def setUp( self ):
         self.app = nofussbm.app
-        self.app.config['TESTING'] = True
+        self.app.config[ 'TESTING' ] = True
         self.client = nofussbm.app.test_client()
 
-    def tearDown(self):
+    def tearDown( self ):
         pass
 
-    def testJson(self):
-        expected_load = [{
+    def testJson( self ):
+        expected_load = [ {
             u'date-modified': datetime.datetime(2016, 7, 16, 0, 0, 43, 237000),
             u'title': u'Google',
             u'url': u'https://google.com',
-            u'tags': [u'google', u'search engine'],
-            u'id': ObjectId('5789792b19f4cb77cc3be929'),
+            u'tags': [ u'google', u'search engine' ],
+            u'id': ObjectId( '5789792b19f4cb77cc3be929' ),
             u'date-added': datetime.datetime(2016, 7, 16, 0, 0, 43, 237000)
-        }]
-        to_load = ('[{'
-                   '"date-added": "2016-07-16 00:00:43.237000", '
-                   '"date-modified": "2016-07-16 00:00:43.237000", '
-                   '"id": "5789792b19f4cb77cc3be929", '
-                   '"tags": "google,search engine", '
-                   '"title": "Google", '
-                   '"url": "https://google.com"'
-                   '}]')
-        expected_dump = ('[{'
-                         '"date-added": "2016-07-16 00:00:43.237000", '
-                         '"date-modified": "2016-07-16 00:00:43.237000", '
-                         '"id": "5789792b19f4cb77cc3be929", '
-                         '"tags": ["google", "search engine"], '
-                         '"title": "Google", '
-                         '"url": "https://google.com"'
-                         '}]')
+        } ]
+        to_load = ( '[{'
+                    '"date-added": "2016-07-16 00:00:43.237000", '
+                    '"date-modified": "2016-07-16 00:00:43.237000", '
+                    '"id": "5789792b19f4cb77cc3be929", '
+                    '"tags": "google,search engine", '
+                    '"title": "Google", '
+                    '"url": "https://google.com"'
+                    '}]' )
+        expected_dump = ( '[{'
+                          '"date-added": "2016-07-16 00:00:43.237000", '
+                          '"date-modified": "2016-07-16 00:00:43.237000", '
+                          '"id": "5789792b19f4cb77cc3be929", '
+                          '"tags": ["google", "search engine"], '
+                          '"title": "Google", '
+                          '"url": "https://google.com"'
+                          '}]' )
 
-        self.assertEqual(self.app.json_encoder, nofussbm.json.NofussbmJSONEncoder)
-        self.assertEqual(self.app.json_decoder, nofussbm.json.NofussbmJSONDecoder)
+        self.assertEqual( self.app.json_encoder, nofussbm.json.NofussbmJSONEncoder )
+        self.assertEqual( self.app.json_decoder, nofussbm.json.NofussbmJSONDecoder )
 
         with self.app.app_context():
-            load = flask.json.loads(to_load)  # expected_dump
-            dump = flask.json.dumps(expected_load)
-            self.assertEqual(load, expected_load)
-            self.assertEqual(dump, expected_dump)
+            load = flask.json.loads( to_load )  # expected_dump
+            dump = flask.json.dumps( expected_load )
+            self.assertEqual( load, expected_load )
+            self.assertEqual( dump, expected_dump )
 
-            tags_as_list_load = flask.json.loads(expected_dump)
-            self.assertEqual(tags_as_list_load, expected_load)
+            tags_as_list_load = flask.json.loads( expected_dump )
+            self.assertEqual( tags_as_list_load, expected_load )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I refactored the function `setup_json(json)` into a class and extended `flask.json.JSONEncoder` and `flask.json.JSONDecoder` to do the same things that function did.
I used a `set` literal in line 39 and I added lines 51-54 in `json.py` to allow users to load tags as list instead of string only, which is the default format `nofussbm` dumps bookmarks in (there's [this line](https://github.com/mapio/nofussbm/blob/0067bf2b21f57a85d79d4908f64b15e1073c1db7/nofussbm/api.py#L143) that joins the list into a comma-separated string).
The tests should assert that the encoder and decoder classes are correct and the data is correctly serialized and deserialized. They can be run with

```
python -m unittest discover
```

from the root of the project.
The test passes on my local machine.
