### PR TITLE
More comprehensive .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,27 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# pyenv
+.python-version
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# PyCharm folder
+.idea/
+
 *.log
 *.pem
 *.json
-.env
 packed
 dump


### PR DESCRIPTION
These rules include exclusion rules for python bytecode cache files and directories, Flask directories such as instance/, .pyenv-version, .env, virtualenv directories and the .idea/ folder used by PyCharm.